### PR TITLE
Adds x86 and x64 build platforms

### DIFF
--- a/ExcelDnaDoc.sln
+++ b/ExcelDnaDoc.sln
@@ -47,25 +47,53 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Debug|x64.ActiveCfg = Debug|x64
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Debug|x64.Build.0 = Debug|x64
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Debug|x86.ActiveCfg = Debug|x86
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Debug|x86.Build.0 = Debug|x86
 		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Release|x64.ActiveCfg = Release|x64
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Release|x64.Build.0 = Release|x64
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Release|x86.ActiveCfg = Release|x86
+		{B46D10F6-9CE3-4E46-AD31-3C44F8D6B51F}.Release|x86.Build.0 = Release|x86
 		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Debug|x64.ActiveCfg = Debug|x64
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Debug|x64.Build.0 = Debug|x64
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Debug|x86.ActiveCfg = Debug|x86
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Debug|x86.Build.0 = Debug|x86
 		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Release|x64.ActiveCfg = Release|x64
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Release|x64.Build.0 = Release|x64
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Release|x86.ActiveCfg = Release|x86
+		{498B3355-81A0-4946-AC0D-DED3B4E14A0D}.Release|x86.Build.0 = Release|x86
 		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5}.Release|x86.ActiveCfg = Release|Any CPU
 		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Release|x64.ActiveCfg = Release|Any CPU
+		{EF06927C-F4F2-48E3-9A26-13F8F994695D}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -78,5 +106,8 @@ Global
 		{498B3355-81A0-4946-AC0D-DED3B4E14A0D} = {D041937F-32C5-472F-BE65-6E1285EC0429}
 		{EB06A18A-DBB0-4AEE-BCE9-325C5FD362F5} = {59032046-AD44-4EF8-B9A0-B75DC1927BAD}
 		{EF06927C-F4F2-48E3-9A26-13F8F994695D} = {59032046-AD44-4EF8-B9A0-B75DC1927BAD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BAE9D09C-1B39-48DD-8847-11540C54ACC8}
 	EndGlobalSection
 EndGlobal

--- a/src/ExcelDna.Documentation/ExcelDna.Documentation.csproj
+++ b/src/ExcelDna.Documentation/ExcelDna.Documentation.csproj
@@ -31,6 +31,46 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\ExcelDna.Documentation.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoWarn>1591</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <DocumentationFile>bin\Release\ExcelDna.Documentation.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoWarn>1591</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <DocumentationFile>bin\Release\ExcelDna.Documentation.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">
       <HintPath>..\..\packages\ExcelDna.Integration.0.33.9\lib\ExcelDna.Integration.dll</HintPath>

--- a/src/ExcelDnaDoc/ExcelDnaDoc.csproj
+++ b/src/ExcelDnaDoc/ExcelDnaDoc.csproj
@@ -30,8 +30,45 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoWarn>1591</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <DocumentationFile>bin\Release\ExcelDna.Documentation.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoWarn>1591</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <DocumentationFile>bin\Release\ExcelDna.Documentation.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">


### PR DESCRIPTION
Fixes #9 

If your library has x86 or x64 compiled-code and COM dependencies, then an AnyCPU build of ExcelDnaDoc will not work, and throws a 'BadFormatException'.

This change allows x86 and x64 builds.
Samples are not built when choosing x86 or x64