### PR TITLE
Improve performance by adding async

### DIFF
--- a/src/ExcelDnaDoc/HtmlHelp.cs
+++ b/src/ExcelDnaDoc/HtmlHelp.cs
@@ -16,7 +16,7 @@
         public static string HelpContentFolderPath { get; set; }
         public static ConcurrentDictionary<string, string> TemplateCache = new ConcurrentDictionary<string, string>();
 
-        public static void Create(string dnaPath, string helpSubfolder = "HelpContent", bool excludeHidden = false, bool skipCompile = false)
+        public static void Create(string dnaPath, string helpSubfolder = "HelpContent", bool excludeHidden = false, bool skipCompile = false, bool runAsync = false)
         {
             BuildFolderPath = Path.GetDirectoryName(dnaPath);
             HelpContentFolderPath = Path.Combine(HtmlHelp.BuildFolderPath, helpSubfolder);
@@ -28,9 +28,9 @@
             if (!Directory.Exists(HelpContentFolderPath)) Directory.CreateDirectory(HelpContentFolderPath);
 
             // HTML Help Workshop content creation
-            Console.WriteLine($"creating HTML Help content in {HelpContentFolderPath}");
-            Console.WriteLine($"ExcludeHidden: {excludeHidden}, SkipCompile: {skipCompile}");
             Console.WriteLine($"Started: {DateTime.Now}");
+            Console.WriteLine($"creating HTML Help content in {HelpContentFolderPath}");
+            Console.WriteLine($"ExcludeHidden: {excludeHidden}, SkipCompile: {skipCompile}, Async: {runAsync}");
             Console.WriteLine();
             
             //Only needed for HelpWorkshop compilation

--- a/src/ExcelDnaDoc/HtmlHelp.cs
+++ b/src/ExcelDnaDoc/HtmlHelp.cs
@@ -1,6 +1,7 @@
 ﻿namespace ExcelDnaDoc
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -12,7 +13,7 @@
     {
         public static string BuildFolderPath { get; set; }
         public static string HelpContentFolderPath { get; set; }
-        public static Dictionary<string, string> TemplateCache = new Dictionary<string, string>();
+        public static ConcurrentDictionary<string, string> TemplateCache = new ConcurrentDictionary<string, string>();
 
         public static void Create(string dnaPath, string helpSubfolder = "HelpContent", bool excludeHidden = false)
         {

--- a/src/ExcelDnaDoc/HtmlHelp.cs
+++ b/src/ExcelDnaDoc/HtmlHelp.cs
@@ -6,6 +6,7 @@
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using ExcelDna.Documentation.Models;
     using ExcelDnaDoc.Templates;
 
@@ -15,7 +16,7 @@
         public static string HelpContentFolderPath { get; set; }
         public static ConcurrentDictionary<string, string> TemplateCache = new ConcurrentDictionary<string, string>();
 
-        public static void Create(string dnaPath, string helpSubfolder = "HelpContent", bool excludeHidden = false)
+        public static void Create(string dnaPath, string helpSubfolder = "HelpContent", bool excludeHidden = false, bool runAsync = true)
         {
             BuildFolderPath = Path.GetDirectoryName(dnaPath);
             HelpContentFolderPath = Path.Combine(HtmlHelp.BuildFolderPath, helpSubfolder);
@@ -34,26 +35,37 @@
             new TableOfContentsView { Model = addin }.Publish();
             new MethodListView { Model = addin }.Publish();
 
+            //Perhaps better to actually enumerate the values?
+            List<Task> tasks = new List<Task>(runAsync ? 5000 : 0);
+
             foreach (var group in addin.Categories) 
             {
-                new CategoryView { Model = group }.Publish();
+                Action categoryAction = new Action(() => new CategoryView { Model = group }.Publish());
+                Run(categoryAction, tasks, runAsync);
 
                 foreach (FunctionModel function in group.Functions) 
                 {
-                    new FunctionView { Model = function }.Publish();
+                    Action functionAction = new Action(() => new FunctionView { Model = function }.Publish());
+                    Run(functionAction, tasks, runAsync);
                 }
             }
 
             // create Excel Commands content
-
             if (addin.Commands.Count() != 0)
             {
                 new CommandListView { Model = addin }.Publish();
 
                 foreach (var command in addin.Commands)
                 {
-                    new CommandView { Model = command }.Publish();
+                    Action commandAction = new Action(() => new CommandView { Model = command }.Publish());
+                    Run(commandAction, tasks, runAsync);
                 }
+            }
+
+            //Will be empty if async not enabled
+            foreach(Task task in tasks)
+            {
+                task.Wait();
             }
 
             // look for style sheet otherwise use embedded one
@@ -87,6 +99,14 @@
             Console.WriteLine("Press any key to exit.");
             Console.ReadKey();
 #endif
+        }
+
+        private static void Run(Action action, List<Task> taskList, bool runAsync)
+        {
+            if (runAsync)
+                taskList.Add(Task.Factory.StartNew(action));
+            else
+                action.Invoke();
         }
     }
 }

--- a/src/ExcelDnaDoc/Program.cs
+++ b/src/ExcelDnaDoc/Program.cs
@@ -16,6 +16,7 @@ Usage: ExcelDnaDoc.exe dnaPath [/X]
   dnaPath                 The path to the primary .dna file for the ExcelDna add-in.
   /ExcludeHidden or /X    Optional. Excludes hidden functions from being documented if provided.
   /SkipCompile or /S      Optional. Skips compiling the HTML Help file (.chm) if provided.
+  /Async or /A            Optional. Runs in async mode, consuming more cpu, but taking less time to run.
 
 Example: ExcelDnaDoc.exe <build folder>\SampleLib-AddIn.dna
          The HTML Help Workshop content will be created in <build folder>\HelpContent\.
@@ -67,7 +68,12 @@ Function Wizard, but will be included in the HTML Help Workshop content.
                         @"/SkipCompile", StringComparison.OrdinalIgnoreCase) || 
                         x.Equals(@"/S", StringComparison.OrdinalIgnoreCase));
 
-                HtmlHelp.Create(dnaPath, excludeHidden: excludeHidden, skipCompile: skipCompile);
+                bool runAsync = args.Any(
+                    x => x.Equals(
+                        @"/Async", StringComparison.OrdinalIgnoreCase) ||
+                        x.Equals(@"/A", StringComparison.OrdinalIgnoreCase));
+
+                HtmlHelp.Create(dnaPath, excludeHidden: excludeHidden, skipCompile: skipCompile, runAsync: runAsync);
             }
         }
     }

--- a/src/ExcelDnaDoc/Utility/ModelHelper.cs
+++ b/src/ExcelDnaDoc/Utility/ModelHelper.cs
@@ -89,15 +89,15 @@
             }
             else
             {
-				//Use reflection to check for matching properties or fields
-				//Adds support to allow people to use their own classes that inherit from ExcelFunctionAttribute
+                //Use reflection to check for matching properties or fields
+                //Adds support to allow people to use their own classes that inherit from ExcelFunctionAttribute
                 var attribs = Attribute.GetCustomAttributes(method);
                 foreach (var attrib in attribs)
                 {
                     if (attrib != null && typeof(ExcelFunctionAttribute).IsAssignableFrom(attrib.GetType()))
                     {
                         string summary = (string)attrib.GetType().GetProperty("Summary")?.GetValue(attrib, null);
-                        if(string.IsNullOrEmpty(summary))
+                        if (string.IsNullOrEmpty(summary))
                             summary = (string)attrib.GetType().GetField("Summary")?.GetValue(attrib);
 
                         string remarks = (string)attrib.GetType().GetProperty("Remarks")?.GetValue(attrib, null);
@@ -127,7 +127,7 @@
                 if (excelFunction.Description != null) { function.Description = excelFunction.Description; }
                 if (excelFunction.HelpTopic != null) { function.TopicId = excelFunction.HelpTopic.Split('!').Last(); }
                 if (excelFunction.Category != null) { function.Category = excelFunction.Category; }
-				function.IsHidden = excelFunction.IsHidden;
+                function.IsHidden = excelFunction.IsHidden;
             }
 
             return function;
@@ -143,7 +143,7 @@
 
             model.DnaFileName = Path.GetFileNameWithoutExtension(dnaPath);
 
-            if (dnaLibrary.Name != null) {model.ProjectName = dnaLibrary.Name;}
+            if (dnaLibrary.Name != null) { model.ProjectName = dnaLibrary.Name; }
             else { model.ProjectName = model.DnaFileName; }
 
             // process function libraries
@@ -157,7 +157,7 @@
                     .SelectMany(t => t.GetMethods())
                     .Where(m => ExcelDnaHelper.IsValidFunction(m, library.ExplicitExports))
                     .Select(m => CreateFunctionModel(m, defaultCategory)))
-                    .Where(m => excludeHidden && !m.IsHidden) //Used to exclude hidden functions
+                    .Where(m => !excludeHidden || (excludeHidden && !m.IsHidden)) //Used to exclude hidden functions
                 .GroupBy(f => f.Category)
                 .Select(g => new CategoryModel { Name = g.Key, Functions = g.OrderBy(f => f.Name) })
                 .OrderBy(c => c.Name);

--- a/src/ExcelDnaDoc/Views/ViewBase.cs
+++ b/src/ExcelDnaDoc/Views/ViewBase.cs
@@ -35,22 +35,22 @@
         public void Publish()
         {
             // check to see if template is in cache
-            if (!HtmlHelp.TemplateCache.ContainsKey(this.TemplateName))
+            string cacheItem = HtmlHelp.TemplateCache.GetOrAdd(this.TemplateName, k=>
             {
                 // look for razorengine template otherwise use embedded one
                 if (File.Exists(this.ViewFilePath))
                 {
                     Console.WriteLine("using local template : " + Path.GetFileName(this.ViewFilePath));
-                    HtmlHelp.TemplateCache.Add(this.TemplateName, File.ReadAllText(this.ViewFilePath));
+                    return File.ReadAllText(this.ViewFilePath);
                 }
                 else
                 {
-                    HtmlHelp.TemplateCache.Add(this.TemplateName, (new UTF8Encoding()).GetString(this.Template));
-                }                
-            }
+                    return (new UTF8Encoding()).GetString(this.Template);
+                }
+            });
 
             // unicode result
-            string content = Razor.Parse(HtmlHelp.TemplateCache[this.TemplateName], this.Model);
+            string content = Razor.Parse(cacheItem, this.Model);
 
             // strip non ANSI characters from result
             content = Regex.Replace(content, @"[^\u0000-\u007F]", string.Empty);


### PR DESCRIPTION
Fixes #22 by adding the optional `/Async` or `/A` option which will make use of available CPU on the box.
Test evidence consists of four runs below, using different configurations.
This also fixes a bug where `/ExcludeHidden` wasn't working correctly (leaving it off resulted in no functions at all).

Note that (on my PC) the full run goes from just under 14 minutes to just under 4 minutes. It was even faster on my build box.

I diffed the resultant folders from these four runs, everything matched, or had expected changes only.

@govert @augustoproiete 

```
Started: 01/06/2018 13:27:41
creating HTML Help content in <snipped>
ExcludeHidden: False, SkipCompile: True, Async: False
Finished: 01/06/2018 13:42:12
[2743 items]

Started: 01/06/2018 13:44:40
creating HTML Help content in <snipped>
ExcludeHidden: False, SkipCompile: True, Async: True
Finished: 01/06/2018 13:48:00
[2743 items, identical to non-async run above]

Started: 01/06/2018 14:16:12
creating HTML Help content in <snipped>
ExcludeHidden: True, SkipCompile: True, Async: False
Finished: 01/06/2018 14:29:21
[2518 items, only expected diffs and missing]

Started: 01/06/2018 14:33:48
creating HTML Help content in <snipped>
ExcludeHidden: True, SkipCompile: True, Async: True
Finished: 01/06/2018 14:36:43
[2518 items, identical to non-async run above]
```