### PR TITLE
Exceldna upgrade

### DIFF
--- a/src/ExcelDna.Documentation/ExcelDna.Documentation.csproj
+++ b/src/ExcelDna.Documentation/ExcelDna.Documentation.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>ExcelDna.Documentation</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -72,8 +74,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\packages\ExcelDna.Integration.0.33.9\lib\ExcelDna.Integration.dll</HintPath>
+    <Reference Include="ExcelDna.Integration, Version=1.0.7056.37028, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ExcelDna.Integration.1.0.0\lib\ExcelDna.Integration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ExcelDna.Documentation/packages.config
+++ b/src/ExcelDna.Documentation/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="0.33.9" targetFramework="net40" />
-  <package id="ExcelDna.Integration" version="0.33.9" targetFramework="net40" />
+  <package id="ExcelDna.AddIn" version="1.0.0" targetFramework="net40" />
+  <package id="ExcelDna.Integration" version="1.0.0" targetFramework="net40" />
 </packages>

--- a/src/ExcelDnaDoc/ExcelDnaDoc.csproj
+++ b/src/ExcelDnaDoc/ExcelDnaDoc.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>ExcelDnaDoc</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -71,8 +73,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\packages\ExcelDna.Integration.0.33.9\lib\ExcelDna.Integration.dll</HintPath>
+    <Reference Include="ExcelDna.Integration, Version=1.0.7056.37028, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ExcelDna.Integration.1.0.0\lib\ExcelDna.Integration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RazorEngine">

--- a/src/ExcelDnaDoc/Program.cs
+++ b/src/ExcelDnaDoc/Program.cs
@@ -68,6 +68,11 @@ Function Wizard, but will be included in the HTML Help Workshop content.
                         x.Equals(@"/S", StringComparison.OrdinalIgnoreCase));
 
                 HtmlHelp.Create(dnaPath, excludeHidden: excludeHidden, skipCompile: skipCompile);
+                Console.WriteLine("Successful");
+#if DEBUG
+                Console.WriteLine("Press any key to exit.");
+                Console.ReadKey();
+#endif
             }
         }
     }

--- a/src/ExcelDnaDoc/Utility/ModelHelper.cs
+++ b/src/ExcelDnaDoc/Utility/ModelHelper.cs
@@ -157,7 +157,7 @@
                     .SelectMany(t => t.GetMethods())
                     .Where(m => ExcelDnaHelper.IsValidFunction(m, library.ExplicitExports))
                     .Select(m => CreateFunctionModel(m, defaultCategory)))
-                    .Where(m => excludeHidden && !m.IsHidden) //Used to exclude hidden functions
+                    .Where(m => !excludeHidden || !m.IsHidden) //Used to exclude hidden functions
                 .GroupBy(f => f.Category)
                 .Select(g => new CategoryModel { Name = g.Key, Functions = g.OrderBy(f => f.Name) })
                 .OrderBy(c => c.Name);

--- a/src/ExcelDnaDoc/packages.config
+++ b/src/ExcelDnaDoc/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="0.33.9" targetFramework="net40" />
-  <package id="ExcelDna.Integration" version="0.33.9" targetFramework="net40" />
+  <package id="ExcelDna.AddIn" version="1.0.0" targetFramework="net40" />
+  <package id="ExcelDna.Integration" version="1.0.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net40" />
 </packages>

--- a/src/samples/MyAddIn/MyAddIn.csproj
+++ b/src/samples/MyAddIn/MyAddIn.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>MyAddIn</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,8 +36,8 @@
       <HintPath>..\..\..\packages\ExcelDnaDoc.0.2.3\lib\net40\ExcelDna.Documentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\..\packages\ExcelDna.Integration.0.33.9\lib\ExcelDna.Integration.dll</HintPath>
+    <Reference Include="ExcelDna.Integration, Version=1.0.7056.37028, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\ExcelDna.Integration.1.0.0\lib\ExcelDna.Integration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -64,11 +66,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDna.xll" "$(TargetDir)MyAddIn.xll*" /C /Y
+    <PostBuildEvent>xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDna.xll" "$(TargetDir)MyAddIn.xll*" /C /Y
 xcopy "$(TargetDir)MyAddIn.dna*" "$(TargetDir)MyAddIn64.dna*" /C /Y
-xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDna64.xll" "$(TargetDir)MyAddIn64.xll*" /C /Y
-"$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDnaPack.exe" "$(TargetDir)MyAddIn.dna" /Y
-"$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDnaPack.exe" "$(TargetDir)MyAddIn64.dna" /Y
+xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDna64.xll" "$(TargetDir)MyAddIn64.xll*" /C /Y
+"$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDnaPack.exe" "$(TargetDir)MyAddIn.dna" /Y
+"$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDnaPack.exe" "$(TargetDir)MyAddIn64.dna" /Y
 "$(SolutionDir)\packages\ExcelDnaDoc.0.2.3\tools\ExcelDnaDoc.exe" "$(TargetDir)MyAddIn.dna" /Y</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/samples/MyAddIn/packages.config
+++ b/src/samples/MyAddIn/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="0.33.9" targetFramework="net40" />
-  <package id="ExcelDna.Integration" version="0.33.9" targetFramework="net40" />
+  <package id="ExcelDna.AddIn" version="1.0.0" targetFramework="net40" />
+  <package id="ExcelDna.Integration" version="1.0.0" targetFramework="net40" />
   <package id="ExcelDnaDoc" version="0.2.3" targetFramework="net40" />
 </packages>

--- a/src/samples/MyLib/MyLib.fsproj
+++ b/src/samples/MyLib/MyLib.fsproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <Name>MyLib</Name>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,7 +25,7 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\MyLib.XML</DocumentationFile>
     <StartAction>Program</StartAction>
-    <StartProgram>C:\Program Files (x86)\Microsoft Office\Root\Office16\EXCEL.EXE</StartProgram>
+    <StartProgram>C:\Program Files (x86)\Microsoft Office\root\Office16\EXCEL.EXE</StartProgram>
     <StartArguments>"MyLib-AddIn.xll"</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -56,11 +58,11 @@
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDna.xll" "$(TargetDir)MyLib-AddIn.xll*" /C /Y
+    <PostBuildEvent>xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDna.xll" "$(TargetDir)MyLib-AddIn.xll*" /C /Y
 xcopy "$(TargetDir)MyLib-AddIn.dna*" "$(TargetDir)MyLib-AddIn64.dna*" /C /Y
-xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDna64.xll" "$(TargetDir)MyLib-AddIn64.xll*" /C /Y
-"$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDnaPack.exe" "$(TargetDir)MyLib-AddIn.dna" /Y
-"$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDnaPack.exe" "$(TargetDir)MyLib-AddIn64.dna" /Y
+xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDna64.xll" "$(TargetDir)MyLib-AddIn64.xll*" /C /Y
+"$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDnaPack.exe" "$(TargetDir)MyLib-AddIn.dna" /Y
+"$(SolutionDir)\packages\ExcelDna.AddIn.1.0.0\tools\ExcelDnaPack.exe" "$(TargetDir)MyLib-AddIn64.dna" /Y
 "$(SolutionDir)\packages\ExcelDnaDoc.0.2.3\tools\ExcelDnaDoc.exe" "$(TargetDir)MyLib-AddIn.dna" /Y</PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
@@ -73,7 +75,7 @@ xcopy "$(SolutionDir)\packages\ExcelDna.AddIn.0.33.9\tools\ExcelDna64.xll" "$(Ta
       <Private>True</Private>
     </Reference>
     <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\..\packages\ExcelDna.Integration.0.33.9\lib\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\..\..\packages\ExcelDna.Integration.1.0.0\lib\ExcelDna.Integration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/samples/MyLib/packages.config
+++ b/src/samples/MyLib/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExcelDna.AddIn" version="0.33.9" targetFramework="net40" />
-  <package id="ExcelDna.Integration" version="0.33.9" targetFramework="net40" />
+  <package id="ExcelDna.AddIn" version="1.0.0" targetFramework="net40" />
+  <package id="ExcelDna.Integration" version="1.0.0" targetFramework="net40" />
   <package id="ExcelDnaDoc" version="0.2.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Upgrades ExcelDnaDoc to use ExcelDna v1.0.0 - assembly version mismatch was causing it to not find any of the ExcelDna attributes.

Also fixed a bug in the exclude hidden function logic that was causing it to exclude and not document all functions.