### PR TITLE
Update Fake and fix build

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fake-cli": {
+      "version": "5.20.4",
+      "commands": [
+        "fake"
+      ]
+    }
+  }
+}

--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,4 @@
 @echo off
-if not exist packages\FAKE\tools\Fake.exe ( 
-  .nuget\nuget.exe install FAKE -OutputDirectory packages -ExcludeVersion
-)
-packages\FAKE\tools\FAKE.exe build.fsx %*
+dotnet tool restore
+dotnet fake run .\build.fsx -- -t %*
 pause

--- a/build.fsx
+++ b/build.fsx
@@ -112,9 +112,9 @@ Target.create "GenerateDocs" (fun _ ->
     Fsi.exec (fun p -> 
         { p with 
             WorkingDirectory = "docs/tools"
-            // ToolPath = FsiTool.External fsiExe
+            Definitions = ["RELEASE"]
         })
-        "generate.fsx" ["--define:RELEASE"] |> ignore
+        "generate.fsx" [] |> ignore
 )
 
 

--- a/build.fsx
+++ b/build.fsx
@@ -2,13 +2,28 @@
 // FAKE build script 
 // --------------------------------------------------------------------------------------
 
-#r "packages/FAKE/tools/FakeLib.dll"
+#r "paket:
+nuget Fake.DotNet.MsBuild
+nuget Fake.DotNet.NuGet
+nuget Fake.DotNet.Fsi
+nuget Fake.DotNet.AssemblyInfoFile
+nuget Fake.Core.Target
+nuget Fake.Core.ReleaseNotes
+nuget Fake.Core.Environment
+nuget Fake.IO.FileSystem
+nuget Fake.Tools.Git
+//"
+#load "./.fake/build.fsx/intellisense.fsx"
 
 open System
 open System.IO
-open Fake 
-open Fake.AssemblyInfoFile
-open Fake.Git
+open Fake.Core
+open Fake.DotNet
+open Fake.IO
+open Fake.DotNet.NuGet
+open Fake.Tools.Git
+
+
 
 // --------------------------------------------------------------------------------------
 // Information about the project to be used at NuGet and in AssemblyInfo files
@@ -26,43 +41,48 @@ let tags = "Excel-DNA Excel"
 let gitHome = "https://github.com/Excel-DNA"
 let gitName = "ExcelDnaDoc"
 
-RestorePackages()
+NuGet.Restore.RestorePackages ()
 
 // Read release notes & version info from RELEASE_NOTES.md
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
 let release = 
     File.ReadLines "RELEASE_NOTES.md" 
-    |> ReleaseNotesHelper.parseReleaseNotes
+    |> ReleaseNotes.parse
 
 // --------------------------------------------------------------------------------------
 // Generate assembly info files with the right version & up-to-date information
 
-Target "AssemblyInfo" (fun _ ->
+Target.create "AssemblyInfo" (fun _ ->
     [ ("src/ExcelDnaDoc/Properties/AssemblyInfo.cs", "ExcelDnaDoc", project, summary)
       ("src/ExcelDna.Documentation/Properties/AssemblyInfo.cs", "ExcelDna.Documentation", project, summary) ]
     |> Seq.iter (fun (fileName, title, project, summary) ->
-        CreateCSharpAssemblyInfo fileName
-           [ Attribute.Title title
-             Attribute.Product project
-             Attribute.Description summary
-             Attribute.Version release.AssemblyVersion
-             Attribute.FileVersion release.AssemblyVersion ] )
+        AssemblyInfoFile.createCSharp fileName
+            [ AssemblyInfo.Title title
+              AssemblyInfo.Product project
+              AssemblyInfo.Description summary
+              AssemblyInfo.Version release.AssemblyVersion
+              AssemblyInfo.FileVersion release.AssemblyVersion ] )
 )
 
 // --------------------------------------------------------------------------------------
 // Clean build results
 
-Target "Clean" (fun _ -> CleanDirs ["bin";"temp"])
+Target.create "Clean" (fun _ -> Shell.cleanDirs ["bin";"temp"])
 
-Target "CleanDocs" (fun _ -> CleanDirs ["docs/output"])
+Target.create "CleanDocs" (fun _ -> Shell.cleanDirs ["docs/output"])
 
 // --------------------------------------------------------------------------------------
 // Build library (builds Visual Studio solution)
 
-Target "Build" (fun _ ->
-    !! "src/ExcelDna.Documentation/ExcelDna.Documentation.csproj"
-    ++ "src/ExcelDnaDoc/ExcelDnaDoc.csproj"
-    |> MSBuildRelease "bin" "Rebuild"
+Target.create "Build" (fun _ ->
+    [ "src/ExcelDna.Documentation/ExcelDna.Documentation.csproj"
+      "src/ExcelDnaDoc/ExcelDnaDoc.csproj" ]
+    |> List.map (MSBuild.build (fun p -> 
+            { p with 
+                Targets = ["ReBuild"]
+            }
+            ) 
+        )
     |> ignore
 //    |> Log "Build-Output: "
 )
@@ -70,8 +90,8 @@ Target "Build" (fun _ ->
 // --------------------------------------------------------------------------------------
 // Build a NuGet package
 
-Target "NuGet" (fun _ ->
-    NuGet (fun p -> 
+Target.create "NuGet" (fun _ ->
+    NuGet.NuGet (fun p -> 
         { p with   
             Authors = authors
             Project = project
@@ -82,8 +102,8 @@ Target "NuGet" (fun _ ->
             Tags = tags
             OutputPath = "bin"
             ToolPath = ".nuget/nuget.exe"
-            AccessKey = getBuildParamOrDefault "nugetkey" ""
-            Publish = hasBuildParam "nugetkey"
+            AccessKey = Environment.environVarOrDefault "nugetkey" ""
+            Publish = Environment.hasEnvironVar "nugetkey"
             Dependencies = [("ExcelDna.Integration", "1.1.0")] })
         "nuget/ExcelDnaDoc.nuspec"
 )
@@ -91,28 +111,34 @@ Target "NuGet" (fun _ ->
 // --------------------------------------------------------------------------------------
 // Generate the documentation
 
-Target "GenerateDocs" (fun _ ->
-    executeFSIWithArgs "docs/tools" "generate.fsx" ["--define:RELEASE"] [] |> ignore
+Target.create "GenerateDocs" (fun _ ->
+    Fsi.exec (fun p -> 
+        { p with 
+            TargetProfile = Fsi.Profile.NetStandard
+            WorkingDirectory = "docs/tools"
+            // ToolPath = FsiTool.External fsiExe
+        })
+        "generate.fsx" ["--define:RELEASE"] |> ignore
 )
 
 
 // --------------------------------------------------------------------------------------
 // Release Scripts
 
-Target "ReleaseDocs" (fun _ ->
+Target.create "ReleaseDocs" (fun _ ->
     Repository.clone "" (gitHome + "/" + gitName + ".git") "temp/gh-pages"
     Branches.checkoutBranch "temp/gh-pages" "gh-pages"
-    CopyRecursive "docs/output" "temp/gh-pages" true |> printfn "%A"
+    Shell.copyRecursive "docs/output" "temp/gh-pages" true |> printfn "%A"
     CommandHelper.runSimpleGitCommand "temp/gh-pages" "add ." |> printfn "%s"
     let cmd = sprintf """commit -a -m "Update generated documentation for version %s""" release.NugetVersion
     CommandHelper.runSimpleGitCommand "temp/gh-pages" cmd |> printfn "%s"
     Branches.push "temp/gh-pages"
 )
 
-Target "ReleaseBinaries" (fun _ ->
+Target.create "ReleaseBinaries" (fun _ ->
     Repository.clone "" (gitHome + "/" + gitName + ".git") "temp/release"
     Branches.checkoutBranch "temp/release" "release"
-    CopyRecursive "bin" "temp/release" true |> printfn "%A"
+    Shell.copyRecursive "bin" "temp/release" true |> printfn "%A"
     CommandHelper.runSimpleGitCommand "temp/release" "add ." |> printfn "%s"
     let cmd = sprintf """commit -a -m "Update binaries for version %s""" release.NugetVersion
     CommandHelper.runSimpleGitCommand "temp/release" cmd |> printfn "%s"
@@ -122,7 +148,7 @@ Target "ReleaseBinaries" (fun _ ->
 // --------------------------------------------------------------------------------------
 // Help
 
-Target "Help" (fun _ ->
+Target.create "Help" (fun _ ->
     printfn ""
     printfn "  Please specify the target by calling 'build <Target>'"
     printfn ""
@@ -138,18 +164,25 @@ Target "Help" (fun _ ->
     printfn "  * Release (calls previous 4)"
     printfn "")
 
-Target "All" DoNothing
 
-"Clean" 
-==> "AssemblyInfo" 
-==> "Build" 
-==> "All"
+Target.create "All" 
+    ignore
+Target.create "Release" 
+    ignore
 
-Target "Release" DoNothing
-"All" ==> "CleanDocs"
-"CleanDocs" ==> "GenerateDocs" ==> "ReleaseDocs"
-"ReleaseDocs" ==> "Release"
+
+open Fake.Core.TargetOperators
+
+"Clean" ==> "AssemblyInfo"  ==> "Build" 
+"Build" ==> "CleanDocs" ==> "GenerateDocs" ==> "ReleaseDocs"
+"Build" ==> "NuGet" ==> "ReleaseBinaries"
+
+
+"Build" ==> "All"
+
 "ReleaseBinaries" ==> "Release"
-"NuGet" ==> "Release"
+"ReleaseDocs" ==> "Release"
 
-RunTargetOrDefault "Help"
+
+
+Target.runOrDefaultWithArguments "Help"

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -23,7 +23,7 @@ let info =
 
 
 #r "nuget: RazorEngine, 3.3.0"
-#r "nuget: FSharp.Formatting, 2.4.0"
+#r "nuget: FSharp.Formatting, 2.13.6"
 #r "nuget: Fake.IO.FileSystem, 5.20.4"
 #r "nuget: Fake.Core.Trace, 5.20.4"
 
@@ -39,8 +39,10 @@ open Fake.IO.FileSystemOperators
 // When called from 'build.fsx', use the public project URL as <root>
 // otherwise, use the current 'output' directory.
 #if RELEASE
+printfn "RELEASE is defined"
 let root = website
 #else
+printfn "RELEASE is not defined"
 let root = "file://" + (__SOURCE_DIRECTORY__ @@ "../output")
 #endif
 
@@ -50,7 +52,7 @@ let content    = __SOURCE_DIRECTORY__ @@ "../content"
 let output     = __SOURCE_DIRECTORY__ @@ "../output"
 let files      = __SOURCE_DIRECTORY__ @@ "../files"
 let templates  = __SOURCE_DIRECTORY__ @@ "templates"
-let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.4.0/"
+let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.13.6/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -20,22 +20,21 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FAKE/tools/"
 
-#I "../../packages/FSharp.Formatting.2.4.0/lib/net40"
-#I "../../packages/RazorEngine.3.3.0/lib/net40/"
-#r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
-#r "../../packages/FAKE/tools/FakeLib.dll"
-#r "RazorEngine.dll"
-#r "FSharp.Literate.dll"
-#r "FSharp.CodeFormat.dll"
-#r "FSharp.MetadataFormat.dll"
 
-open Fake
+#r "nuget: RazorEngine, 3.3.0"
+#r "nuget: FSharp.Formatting, 2.4.0"
+#r "nuget: Fake.IO.FileSystem, 5.20.4"
+#r "nuget: Fake.Core.Trace, 5.20.4"
+
+
+open Fake.IO
+open Fake.Core
 open System.IO
-open Fake.FileHelper
 open FSharp.Literate
 open FSharp.MetadataFormat
+
+open Fake.IO.FileSystemOperators
 
 // When called from 'build.fsx', use the public project URL as <root>
 // otherwise, use the current 'output' directory.
@@ -61,14 +60,14 @@ let layoutRoots =
 
 // Copy static files and CSS + JS from F# Formatting
 let copyFiles () =
-  CopyRecursive files output true |> Log "Copying file: "
-  ensureDirectory (output @@ "content")
-  CopyRecursive (formatting @@ "styles") (output @@ "content") true 
-    |> Log "Copying styles and scripts: "
+  Shell.copyRecursive files output true |> Trace.logItems "Copying file: " |> ignore
+  Directory.ensure (output @@ "content" )
+  Shell.copyRecursive (formatting @@ "styles") (output @@ "content") true 
+    |> Trace.logItems "Copying styles and scripts: "
 
 // Build API reference from XML comments
 let buildReference () =
-  CleanDir (output @@ "reference")
+  Shell.cleanDir (output @@ "reference")
   for lib in referenceBinaries do
     MetadataFormat.Generate
       ( bin @@ lib, output @@ "reference", layoutRoots, 

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -39,10 +39,8 @@ open Fake.IO.FileSystemOperators
 // When called from 'build.fsx', use the public project URL as <root>
 // otherwise, use the current 'output' directory.
 #if RELEASE
-printfn "RELEASE is defined"
 let root = website
 #else
-printfn "RELEASE is not defined"
 let root = "file://" + (__SOURCE_DIRECTORY__ @@ "../output")
 #endif
 

--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Formatting" version="2.4.0" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.13.6" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
 </packages>

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -7,10 +7,10 @@
     <meta name="description" content="@Description">
     <meta name="author" content="@Properties["project-author"]">
 
-    <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="http://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
+    <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
+    <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
+    <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
 
     <link type="text/css" rel="stylesheet" href="@Root/content/style.css" />
     <script type="text/javascript" src="@Root/content/tips.js"></script>


### PR DESCRIPTION
Fixes #27 - Upgrade to Fake 5
This adds a few dependencies:
- a recent `dotnet` framework
  - to run `dotnet tool restore` and install `fake-cli`)
- a version of FSI with F# 5
  - to support the "#r nuget:..." package reference in `docs/tools/generate.fsx`
  - at the moment I believe it relies on what's in the path, and that's probably the `fsi.exe` that comes with VS
  - I just realised we could get it from `dotnet tool` also

I've modified what was necessary to convert all 'links' (css, fonts, ...) to https - the browser was complaining about those and refusing to load them.

I've done a ReleaseDocs test on [https://pierreyvesr.github.io/ExcelDnaDoc/](https://pierreyvesr.github.io/ExcelDnaDoc/), and it looks ok.
I haven't tested the nuget deploy or inspected the nuget package.

